### PR TITLE
Using the syntax before results in false as class names

### DIFF
--- a/src/components/bbox/Bbox.tsx
+++ b/src/components/bbox/Bbox.tsx
@@ -90,7 +90,7 @@ const Bbox: FC<IBboxProps> = (props) => {
     ]
   } ,[props.bbox.location, props.scale]);
 
-  return <BboxDiv className={`pdf-bbox ${props.selected && 'pdf-bbox_selected'} ${props.related && 'pdf-bbox_related'}`}
+  return <BboxDiv className={`pdf-bbox${props.selected ? ' pdf-bbox_selected' : ''}${props.related ? ' pdf-bbox_related' : ''}`}
                   left={left}
                   bottom={bottom}
                   width={width}

--- a/src/components/pdfPage/PdfPage.tsx
+++ b/src/components/pdfPage/PdfPage.tsx
@@ -165,7 +165,7 @@ const PdfPage: FC<IPdfPageProps> = (props) => {
 
   return (
     <StyledPdfPage
-      className={`pdf-page pdf-page_rendered ${props.isPageSelected  && 'pdf-page_selected'}`}
+      className={`pdf-page pdf-page_rendered${props.isPageSelected ? ' pdf-page_selected' : ''}`}
       data-page={props.page}
       onClick={onPageClick}
       height={!isRendered ? props.height || props.defaultHeight : undefined}


### PR DESCRIPTION
<img width="324" alt="image" src="https://github.com/veraPDF/verapdf-js-viewer/assets/17402724/a77dce39-2ff5-4a1e-89a9-3d721b5279dc">
